### PR TITLE
Clean queries before contacting the API

### DIFF
--- a/define.rb
+++ b/define.rb
@@ -1,6 +1,7 @@
 require 'cinch'
 require 'open-uri'
 require 'json'
+require 'uri'
 
 # API GUIDE 101!
 # http://api.duckduckgo.com/?q=#{b}&format=json&pretty=1
@@ -15,11 +16,7 @@ class Define
 
   def execute(m, query)
 
-    if is_single_word(query)
-      b = query
-    else
-      b = query.split.join("+")
-    end
+    b = URI.escape(query)
 
     parsedJSON = open("http://api.duckduckgo.com/?q=#{b}&format=json") { |f| JSON.parse f.read }
     if parsedJSON["RelatedTopics"].length > 0

--- a/define.rb
+++ b/define.rb
@@ -30,9 +30,4 @@ class Define
         m.reply "Don't fuck wid me!!"
     end
   end
-
-  def is_single_word(string)
-    string.strip == string and string.include?(" ")
-  end
-  
 end


### PR DESCRIPTION
I think there's a problem with `is_single_word(string)` as stated on issue #4 

Besides that, it's always a good idea to clean(URI escape) search queries before sending them to the API.